### PR TITLE
Fix a comment

### DIFF
--- a/sixel.hpp
+++ b/sixel.hpp
@@ -43,7 +43,7 @@ private:
         // ? ... ~
         // - : LF (beginning of the next line)
         // $ : CR (beginning of the current line)
-        // #0;2;r;g;b : color
+        // #10;2;r;g;b : color
 
         std::vector<std::string> escaped_lines;
 


### PR DESCRIPTION
I think the right escape sequence to set color is `#10;2;r;g;b`, not `#0;2;r;g;b`.